### PR TITLE
fix typo in requirements and indentation error in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,4 +92,4 @@ data/tmp/exports-etalab.zip:
 	unzip data/tmp/exports-etalab.zip declaration*csv -d data/tmp/
 
 data/rpps.csv:
-        bash scripts/download_rpps.sh
+	bash scripts/download_rpps.sh

--- a/README
+++ b/README
@@ -3,7 +3,7 @@ Collect Sunshine data
 
 - Dependencies:
 ```bash
-pip install cvskit pandas unidecode
+pip install csvkit pandas unidecode
 ```
 
 - Generate data:


### PR DESCRIPTION
here we go :+1: 

I'm having another problem too with the Makefile rules (`make: *** No rule to make target `data/refined/declaration_conventions.refined.csv', needed by `data/all.csv'.  Stop.`) but I did a quick local fix to hardcode the file name instead of using `%`)

EDIT: Also, looks like it's only-compatible with `python3` (that's a good thing, I strangely assumed it would use `python2`)

EDIT2: Also, there's `numpy` and `pandas` as a missing dependency